### PR TITLE
Introduce DualObjectSourceOperator in the relational algebra model.

### DIFF
--- a/ingraph-cypher2relalg/src/main/java/ingraph/cypher2relalg/RelalgBuilder.xtend
+++ b/ingraph-cypher2relalg/src/main/java/ingraph/cypher2relalg/RelalgBuilder.xtend
@@ -188,13 +188,18 @@ class RelalgBuilder {
       ]
     ]
 
-    /*
-     * The compiled form of the first MATCH clause is on the rightInput
-     * of the first join operator.
-     *
-     * This join operator is in fact, unnecessary.
-     */
-    val content = chainBinaryOperatorsLeft(singleQuery_MatchList?.head?.rightInput, singleQuery_MatchList?.tail)
+    // if there is no match clause or the first is already an "OPTIONAL MATCH", we include the dual source
+    val content = if (singleQuery_MatchList.empty || singleQuery_MatchList.head instanceof LeftOuterJoinOperator) {
+      chainBinaryOperatorsLeft(createDualObjectSourceOperator, singleQuery_MatchList)
+    } else {
+      /*
+       * The compiled form of the first MATCH clause is on the rightInput
+       * of the first join operator.
+       *
+       * This join operator is in fact, unnecessary.
+       */
+      chainBinaryOperatorsLeft(singleQuery_MatchList?.head?.rightInput, singleQuery_MatchList?.tail)
+    }
 
     //val singleQuery_unwindClauseList =
     clauses.filter(typeof(Unwind)).forEach[buildRelalgUnwind(it, content)]

--- a/ingraph-cypher2relalg/src/main/java/ingraph/cypher2relalg/util/Validator.xtend
+++ b/ingraph-cypher2relalg/src/main/java/ingraph/cypher2relalg/util/Validator.xtend
@@ -16,16 +16,12 @@ class Validator {
    *
    * Checks performed:
    * - Currently we support only single queries having at least 1 MATCH caluse
-   * - We don't yet support starting with an OPTIONAL MATCH
    * - It is invalid to have MATCH after OPTIONAL MATCH.
    */
   def static void checkMatchClauseSequence(Iterable<Match> singleQuery_MatchList, IngraphLogger logger) {
     val head = singleQuery_MatchList?.head
     if (head == null) {
       logger.unsupported('''Currently we support only single queries having at least 1 MATCH caluse''')
-    } else if (head.optional) {
-      // FIXME: #40
-      logger.unsupported("We don't yet support starting with an OPTIONAL MATCH")
     } else {
       var seenOptionalMatch = false
       for (Match o : singleQuery_MatchList) {

--- a/ingraph-relalg-model/src/main/resources/relalg.xcore
+++ b/ingraph-relalg-model/src/main/resources/relalg.xcore
@@ -204,6 +204,12 @@ class GetVerticesOperator extends NullaryOperator {
   refers VertexVariable vertexVariable
 }
 
+/**
+ * Dual graph object source, that should always return a single tuple, i.e. ()
+ */
+class DualObjectSourceOperator extends NullaryOperator {
+}
+
 // (sourceVertexVariable)-[edgeVariable]->(targetVertexVariable)
 class GetEdgesOperator extends NullaryOperator {
   refers VertexVariable sourceVertexVariable

--- a/ingraph-relalg2tex/src/main/java/ingraph/relalg2tex/OperatorConverter.xtend
+++ b/ingraph-relalg2tex/src/main/java/ingraph/relalg2tex/OperatorConverter.xtend
@@ -5,6 +5,7 @@ import relalg.AbstractJoinOperator
 import relalg.AllDifferentOperator
 import relalg.AntiJoinOperator
 import relalg.BinaryOperator
+import relalg.DualObjectSourceOperator
 import relalg.DuplicateEliminationOperator
 import relalg.ExpandOperator
 import relalg.GetEdgesOperator
@@ -59,6 +60,12 @@ class OperatorConverter {
   def dispatch convertOperator(GetVerticesOperator op) {
     #[
       '''\getvertices«op.vertexVariable.convertElement»'''
+    ]
+  }
+
+  def dispatch convertOperator(DualObjectSourceOperator op) {
+    #[
+      '''\var{DualGraphObjectSource}'''
     ]
   }
 


### PR DESCRIPTION
This way we can handle subqueries that have
* OPTIONAL MATCH as the first match clause
* no MATCH clauses at all