### PR TITLE
Change ingraph-deps repo 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ subprojects {
     jcenter()
     maven { url 'https://repo.eclipse.org/content/groups/acceleo' }
     maven { url 'https://repo.eclipse.org/content/groups/viatra2' }
-    maven { url 'http://docs.inf.mit.bme.hu/ingraph-deps' }
+    maven { url 'https://szdavid92.github.io/ingraph-deps' }
   }
 
   // disable warnings for Scala projects


### PR DESCRIPTION
Change ingraph-deps repo to https://szdavid92.github.io/ingraph-deps as workaround

The original site redirects to the custom domain that lacks the SSL cert. Let's do this until we acquire it. The ingraph team has write access to this repo.