### PR TITLE
return iterators from Indexer getters, and stop throwing errors

### DIFF
--- a/ingraph-engine/ingraph-engine-ingraph-ire/src/main/scala/ingraph/ire/Indexer.scala
+++ b/ingraph-engine/ingraph-engine-ingraph-ire/src/main/scala/ingraph/ire/Indexer.scala
@@ -111,12 +111,14 @@ class Indexer {
     edgeLookup.remove(id)
   }
 
-  def vertexById(id: Long): IngraphVertex = vertexLookup(id)
-  def edgeById(id: Long): IngraphEdge = edgeLookup(id)
-  def verticesByLabel(label: String): Seq[IngraphVertex] = vertexLabelLookup(label)
-  def edgesByLabel(label: String): Seq[IngraphEdge] = edgeLabelLookup(label)
-  def getNumberOfVerticesWithLabel(label: String): Int =  vertexLabelLookup(label).size
-  def getNumberOfEdgesWithLabel(label: String): Int = edgeLabelLookup(label).size
+  def vertexById(id: Long): Option[IngraphVertex] = vertexLookup.get(id)
+  def edgeById(id: Long): Option[IngraphEdge] = edgeLookup.get(id)
+  def vertices(): Iterator[IngraphVertex] = vertexLabelLookup.valuesIterator.flatten
+  def verticesByLabel(label: String): Iterator[IngraphVertex] = vertexLabelLookup.getOrElse(label, Seq()).iterator
+  def edges(): Iterator[IngraphEdge] = edgeLookup.valuesIterator
+  def edgesByLabel(label: String): Iterator[IngraphEdge] = edgeLabelLookup.getOrElse(label, Seq()).iterator
+  def getNumberOfVerticesWithLabel(label: String): Int =  vertexLabelLookup.get(label).map(_.size).getOrElse(0)
+  def getNumberOfEdgesWithLabel(label: String): Int = edgeLabelLookup.get(label).map(_.size).getOrElse(0)
 
   val rnd = new Random(1)
   def newId(): Long = {

--- a/ingraph-engine/ingraph-engine-ingraph-ire/src/test/scala/ingraph/ire/IndexerTest.scala
+++ b/ingraph-engine/ingraph-engine-ingraph-ire/src/test/scala/ingraph/ire/IndexerTest.scala
@@ -19,7 +19,7 @@ class IndexerTest extends WordSpec {
 
   "IngraphEdge" should {
     "reverse itself" in {
-      val edge: IngraphEdge = indexer.edgesByLabel("eats").head
+      val edge: IngraphEdge = indexer.edgesByLabel("eats").toSeq.head
       val inverse = edge.inverse()
       assert(edge.sourceVertex == inverse.targetVertex)
       assert(inverse.sourceVertex == edge.targetVertex)
@@ -34,12 +34,12 @@ class IndexerTest extends WordSpec {
     }
 
     "return vertices by id" in {
-      assert(indexer.vertexById(3).id == 3)
+      assert(indexer.vertexById(3).map(_.id) == Some(3))
     }
 
     "make create navigable entities" in {
-      assert(indexer.vertexById(2).edges("owns").sourceVertex.id == 2)
-      assert(indexer.vertexById(2).reverseEdges("owns").targetVertex.id == 2)
+      assert(indexer.vertexById(2).map(_.edges("owns").sourceVertex.id) == Some(2))
+      assert(indexer.vertexById(2).map(_.reverseEdges("owns").targetVertex.id) == Some(2))
     }
   }
 }


### PR DESCRIPTION
Indexer doesn't throw anymore.