### PR TITLE
Refactor constraint lookup

### DIFF
--- a/sre-adapter/project.clj
+++ b/sre-adapter/project.clj
@@ -1,7 +1,7 @@
 (defproject ingraph/sre-adapter "0.4.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [ingraph/sre "0.2.0-SNAPSHOT"]
-                 [ingraph/ire-adapter "0.2.0-SNAPSHOT"]]
+                 [ingraph/sre "0.4.0-SNAPSHOT"]
+                 [ingraph/ire-adapter "0.4.0-SNAPSHOT"]]
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]
   :resource-paths ["src/main/resource"]

--- a/sre-adapter/src/test/scala/ingraph/sre/SearchPlanCompilerTest.scala
+++ b/sre-adapter/src/test/scala/ingraph/sre/SearchPlanCompilerTest.scala
@@ -9,7 +9,8 @@ import ingraph.sre.plan.{DirectedEdgeConstraintBinding, GetEdgesOperationBinding
 import org.junit.runner.RunWith
 import org.scalatest.FreeSpec
 import org.scalatest.junit.JUnitRunner
-import sre.plan.compiler.{ConstraintLookupFactory, SearchPlanCompiler}
+import sre.plan.compiler.SearchPlanCompiler
+import sre.plan.lookup.ConstraintLookupFactory
 
 @RunWith(classOf[JUnitRunner])
 class SearchPlanCompilerTest extends FreeSpec {

--- a/sre/src/sre/plan/dsl/constraint.clj
+++ b/sre/src/sre/plan/dsl/constraint.clj
@@ -12,15 +12,17 @@
 (defprotocol IConstraintBinding
   (implies [this] "Returns direct implications")
   (implies* [this] "Returns closure of implications")
-  (impliesTransitiveClosure [this] "An alias for implies*. Must do the same thing as implies*"))
+  (impliesTransitively [this] "An alias for implies*"))
 
 (declare -implies -implies*)
+
+(defn union* [& constrs] (reduce #(union %1 (implies* %2)) #{} constrs))
 
 (defrecord ConstraintBinding [^Var type bindings]
   IConstraintBinding
   (implies [this] (-implies this))
   (implies* [this] (-implies* this))
-  (impliesTransitiveClosure [this] (implies* this)))
+  (impliesTransitively [this] (implies* this)))
 
 (defn- -implies
   ^IPersistentSet [^ConstraintBinding {type :type bindings :bindings}]

--- a/sre/src/sre/plan/lookup.clj
+++ b/sre/src/sre/plan/lookup.clj
@@ -1,0 +1,108 @@
+(ns sre.plan.lookup
+  (:require
+    [clojure.algo.generic.functor :refer :all]
+    [clojure.set :refer :all]
+    [sre.plan.dsl.constraint :refer :all])
+  (:import (clojure.lang IPersistentSet)))
+
+(defprotocol IConstraintLookup
+  (lookup [this cond] "Gets free/bound constraints. `cond` should be :free or :bound.")
+  (lookup-by-type [this cond] "Gets free/bound constraint *bindings* for by type.
+  It doesn't return the whole ConstraintBinding only the :bindings part of it!
+  (It is trivial to create one as you know the type already")
+  (lookup-by-var [this cond] "Gets free/bound constraints by var")
+  (bind [this constraint] "If the constraint is free move it to bound, else don't do a thing"))
+
+(defn- create-by-type [bindings]
+  (reduce (fn [lkp {type :type bindings :bindings}]
+            (if (lkp type)
+              (update-in lkp [type] #(conj % bindings))
+              (assoc lkp type #{bindings})))
+          {}
+          bindings))
+
+(defn- create-by-var [bindings]
+  (reduce (fn [lkp {vars :bindings :as constraint-binding}]
+            (reduce (fn [lkp var]
+                      (if (lkp var)
+                        (update-in lkp [var] #(conj % constraint-binding))
+                        (assoc lkp var #{constraint-binding})))
+                    lkp
+                    vars))
+          {}
+          bindings))
+
+(defn- -bind [constr-lkp constraint]
+  (if-not ((lookup constr-lkp :free) constraint)
+    constr-lkp
+    (let [{type :type bindings :bindings} constraint]
+      (-> constr-lkp
+          (update-in [:free :by-type] #(if (= 1 (count (%1 type)))
+                                         ; as an optimization don't leave empty keys hanging in the map
+                                         (dissoc %1 type)
+                                         (update-in %1 [type] (fn [s] (disj s bindings)))))
+          (update-in [:free :by-var] (fn [by-var] (reduce #(if (= 1 (count (%1 %2)))
+                                                             ; as an optimization don't leave empty keys hanging in the map
+                                                             (dissoc %1 %2)
+                                                             (update-in %1 [%2] (fn [s] (disj s constraint))))
+                                                          by-var
+                                                          bindings)))
+          (update-in [:free :constraints] #(disj % constraint))
+          (update-in [:bound :by-type] #(merge-with union {type #{bindings}} %))
+          (update-in [:bound :by-var] (fn [by-var] (reduce #(merge-with union {%2 #{constraint}} %1)
+                                                           by-var
+                                                           bindings)))
+          (update-in [:bound :constraints] #(conj % constraint))))))
+
+;; I don't want to hassle with implementing ILookup because
+;; that would override how get (and probably update) works, and that would make
+;; working with this code a total mess I fear.
+
+(defrecord ConstraintLookup [free bound]
+  IConstraintLookup
+  (lookup [this cond] (-> this cond :constraints))
+  (lookup-by-type [this cond] (-> this cond :by-type))
+  (lookup-by-var [this cond] (-> this cond :by-var))
+  (bind [this constraint] (-bind this constraint)))
+
+(defn constraint-lookup
+  "Factory function to create a ConstraintLookup from free and bound constraints.
+  Will not expand implications."
+  (^ConstraintLookup [free bound]
+   (let [free (into #{} free)
+         bound (into #{} bound)]
+     (map->ConstraintLookup {:free  {:constraints free
+                                     :by-type     (create-by-type free)
+                                     :by-var      (create-by-var free)}
+                             :bound {:constraints bound
+                                     :by-type     (create-by-type bound)
+                                     :by-var      (create-by-var bound)}})))
+  (^ConstraintLookup [free] (constraint-lookup free nil))
+  (^ConstraintLookup [] (constraint-lookup nil)))
+
+;; Convienience methods for Java users :)
+
+(defn ConstraintLookupFactory-fromFreeConstrsClosureAndBoundConstrsClosure ^ConstraintLookup [^Iterable free ^Iterable bound]
+  (constraint-lookup (seq free) (seq bound)))
+
+(defn ConstraintLookupFactory-fromFreeConstrsClosure ^ConstraintLookup [^Iterable free]
+  (constraint-lookup (seq free)))
+
+(defn ConstraintLookupFactory-fromFreeConstrs ^ConstraintLookup [^Iterable free]
+  (constraint-lookup (apply union* (seq free))))
+
+(defn ConstraintLookupFactory-fromAllConstrsClosureAndBoundConstrsClosure ^ConstraintLookup [^Iterable all ^Iterable bound]
+  (constraint-lookup (difference (into #{} all) (into #{} bound)) (seq bound)))
+
+(defn ConstraintLookupFactory-fromAllConstrsAndBoundConstrs ^ConstraintLookup [^Iterable all ^Iterable bound]
+  (constraint-lookup (difference (apply union* (seq all)) (apply union* (seq bound))) (seq bound)))
+
+(gen-class
+  :name sre.plan.lookup.ConstraintLookupFactory
+  :prefix "ConstraintLookupFactory-"
+  :main false
+  :methods [^:static [fromFreeConstrsClosureAndBoundConstrsClosure [Iterable Iterable] sre.plan.lookup.ConstraintLookup]
+            ^:static [fromFreeConstrsClosure [Iterable] sre.plan.lookup.ConstraintLookup]
+            ^:static [fromFreeConstrs [Iterable] sre.plan.lookup.ConstraintLookup]
+            ^:static [fromAllConstrsClosureAndBoundConstrsClosure [Iterable Iterable] sre.plan.lookup.ConstraintLookup]
+            ^:static [fromAllConstrsAndBoundConstrs [Iterable Iterable] sre.plan.lookup.ConstraintLookup]])

--- a/sre/test/sre/plan/lookup_test.clj
+++ b/sre/test/sre/plan/lookup_test.clj
@@ -1,0 +1,28 @@
+(ns sre.plan.lookup-test
+  (:require [clojure.test :refer :all]
+            [clojure.pprint :refer :all]
+            [sre.plan.config-1 :refer :all]
+            [sre.plan.dsl.constraint :refer :all]
+            [sre.plan.lookup :refer :all]))
+
+(deftest test-lookup
+  (let [free #{(->ConstraintBinding #'TestConstraint01 [1])
+               (->ConstraintBinding #'TestConstraint02 [1 2])}
+        bound #{(->ConstraintBinding #'TestConstraint01 [2])}
+        lkp (constraint-lookup free bound)]
+    (testing "Can query constraint-lookup"
+      (is (= (lookup lkp :free) free))
+      (is (= (get (lookup-by-type lkp :free) #'TestConstraint01) #{[1]}))
+      (is (= (get (lookup-by-var lkp :free) 1) free))
+      (is (= (get (lookup-by-var lkp :bound) 2) bound))
+      (is (= (get (lookup-by-var lkp :free) 2) #{(->ConstraintBinding #'TestConstraint02 [1 2])})))
+    (testing "Can move free to bound"
+      (let [lkp (bind lkp (->ConstraintBinding #'TestConstraint02 [1 2]))]
+        (is (= (lookup lkp :free) #{(->ConstraintBinding #'TestConstraint01 [1])}))
+        (is (empty? (get (lookup-by-type lkp :free) #'TestConstraint02)))
+        (is (= (get (lookup-by-type lkp :free) #'TestConstraint01) #{[1]}))
+        (is (empty? (get (lookup-by-var lkp :free) 2)))
+        (is (= (get (lookup-by-var lkp :free) 1) #{(->ConstraintBinding #'TestConstraint01 [1])}))
+        (is (= (get (lookup-by-var lkp :bound) 1) #{(->ConstraintBinding #'TestConstraint02 [1 2])}))
+        (is (= (get (lookup-by-var lkp :bound) 2) #{(->ConstraintBinding #'TestConstraint01 [2])
+                                                    (->ConstraintBinding #'TestConstraint02 [1 2])}))))))


### PR DESCRIPTION
Yeyy! The ubiquitous all-pervasive "ConstraintLookup" is getting a name and getting out of compiler. Additionally to segrating it which will largely enhance readability of the search plan calculation it gets an efficient lookup-by-var functionality. ie you can look up constraints by the variables they contain. How cool is that?

(Probably it will be useful for estimation.)