### PR TITLE
Support configuration layers

### DIFF
--- a/sre/src/sre/execution/executor.clj
+++ b/sre/src/sre/execution/executor.clj
@@ -1,6 +1,6 @@
 (ns sre.execution.executor
-  (:require [clojure.zip :as z])
-  (:require [sre.plan.task :refer :all])
+  (:require [clojure.zip :as z]
+            [sre.plan.task :refer :all])
   (:import (clojure.lang LazySeq PersistentHashMap PersistentList)
            (java.util Vector)
            (sre.plan.task SearchTreeState)))

--- a/sre/src/sre/plan/compiler.clj
+++ b/sre/src/sre/plan/compiler.clj
@@ -268,6 +268,8 @@
               (recur plans))))
         (failure (Exception. "no solution"))))))
 
+
+
 (defn SearchPlanCompiler-calculate ^SearchPlanCell [^Cost cost-calculator ^Weight weight-calculator ^Integer k ^IPersistentSet ops ^ConstraintLookup constr-lkp]
   @(calculate-search-plan cost-calculator weight-calculator k ops constr-lkp))
 


### PR DESCRIPTION
Adds a function for dynamically creating configs. This will come in handy for patterns. You can specify an underlying config upon which
this one will be layered. Constraints and operations will be united, name will be overshadowed
weight and task methods will be coalesced in a way that first the upper config will be checked then
if not found dispatch will fall through to the underlying multimethod.