### PR TITLE
Use typed Xtext modeling of unary operators in compiler

### DIFF
--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
@@ -22,7 +22,7 @@ object ExpressionBuilder {
       case e: oc.ExpressionAnd => cExpr.And(buildExpression(e.getLeft, joins), buildExpression(e.getRight, joins))
       case e: oc.ExpressionOr => cExpr.Or(buildExpression(e.getLeft, joins), buildExpression(e.getRight, joins))
       case e: oc.ExpressionXor => buildExpressionXor(e, joins)
-      case e if "not".equalsIgnoreCase(e.getOperator) => cExpr.Not(buildExpression(e.getLeft, joins))
+      case e: oc.ExpressionNot => cExpr.Not(buildExpression(e.getLeft, joins))
       //TODO: case e: oc.InCollectionExpression => buildExpressionAux(e, joins)
       case e: oc.IsNotNullExpression => cExpr.IsNotNull(expr.EStub()) //FIXME: ce.vb.buildRelalgVariable(e.left)
       case e: oc.IsNullExpression => cExpr.IsNull(expr.EStub()) //FIXME: ce.vb.buildRelalgVariable(e.left)

--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
@@ -32,10 +32,7 @@ object ExpressionBuilder {
       //FIXME: case e: oc.StartsWithExpression => cExpr.StartsWith(buildExpression(e.getLeft), buildExpression(e.getRight))
       case e: oc.ExpressionNodeLabelsAndPropertyLookup => AttributeBuilder.buildAttribute(e)
       case e: oc.ExpressionPlusMinus => buildExpressionArithmetic(e, joins)
-      case e: oc.Expression if Set("-", "+") contains e.getOperator => e.getOperator match {
-        case "-" => cExpr.UnaryMinus(buildExpression(e.getLeft, joins))
-        case "+" => cExpr.UnaryPositive(buildExpression(e.getLeft, joins))
-      }
+      case e: oc.ExpressionUnaryPlusMinus => buildExpressionArithmetic(e, joins)
       case e: oc.ExpressionMulDiv => buildExpressionArithmetic(e, joins)
       case e: oc.ExpressionPower => buildExpressionArithmetic(e, joins)
       //FIXME#206: this should pass function name unresolved
@@ -157,6 +154,16 @@ object ExpressionBuilder {
     e.getOperator match {
       case "+" => cExpr.Add(l, r)
       case "-" => cExpr.Subtract(l, r)
+    }
+  }
+
+  def buildExpressionArithmetic(e: oc.ExpressionUnaryPlusMinus, joins: ListBuffer[qplan.QNode]): cExpr.Expression = {
+    // process them only once because of the possible joins there
+    val l = buildExpression(e.getLeft, joins)
+
+    e.getOperator match {
+      case "-" => cExpr.UnaryMinus(l)
+      case "+" => cExpr.UnaryPositive(l)
     }
   }
 

--- a/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
@@ -11,7 +11,7 @@ class TrainBenchmarkCompilationTest extends FunSuite {
   test("Random test from cypher string") {
     TrainBenchmarkCompilationTest.testQueryString(
       """MATCH (segment:Segment)
-        |WHERE segment.length <= 0
+        |WHERE NOT NOT NOT (segment.length > 0)
         |RETURN segment, segment.length AS length
         |     , case segment.length when +0 then 'zero' when --+-1 then 'almost OK' else 'too bad' end AS lengthComment""".stripMargin)
 

--- a/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
@@ -13,7 +13,7 @@ class TrainBenchmarkCompilationTest extends FunSuite {
       """MATCH (segment:Segment)
         |WHERE segment.length <= 0
         |RETURN segment, segment.length AS length
-        |     , case segment.length when +0 then 'zero' when -1 then 'almost OK' else 'too bad' end AS lengthComment""".stripMargin)
+        |     , case segment.length when +0 then 'zero' when --+-1 then 'almost OK' else 'too bad' end AS lengthComment""".stripMargin)
 
   }
 


### PR DESCRIPTION
This should be merged once we upgrade the openCypher Xtext grammar to a version that includes the appropriate changes.

Ref: slizaa/slizaa-opencypher-xtext#8