### PR TITLE
Grammar enhancements: case and union

### DIFF
--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ExpressionBuilder.scala
@@ -203,32 +203,27 @@ object ExpressionBuilder {
 //    }
 //  }
 
-  def buildExpressionCase(e: oc.CaseExpression): cExpr.Expression = {
-    e.getExpression match {
-      case caseExpr: oc.CaseExpression => {
-        val elseExpr: Option[cExpr.Expression] = caseExpr.getElseExpression match {
-          case e: Any => Some(buildExpressionNoJoinAllowed(e))
-          case _ => None
-        }
+  def buildExpressionCase(caseExpr: oc.CaseExpression): cExpr.Expression = {
+    val elseExpr: Option[cExpr.Expression] = caseExpr.getElseExpression match {
+      case e: Any => Some(buildExpressionNoJoinAllowed(e))
+      case _ => None
+    }
 
-        val branches: Seq[(cExpr.Expression, cExpr.Expression)] = caseExpr.getCaseAlternatives.asScala.map( ca => { //(condExpr, valueExpr)
-          (buildExpressionNoJoinAllowed(ca.getWhen), buildExpressionNoJoinAllowed(ca.getThen))
-        })
+    val branches: Seq[(cExpr.Expression, cExpr.Expression)] = caseExpr.getCaseAlternatives.asScala.map( ca => { //(condExpr, valueExpr)
+      (buildExpressionNoJoinAllowed(ca.getWhen), buildExpressionNoJoinAllowed(ca.getThen))
+    })
 
-        caseExpr.getCaseExpression match {
-          case e: Any => {
-            val simpleCaseExpression: cExpr.Expression = buildExpressionNoJoinAllowed(e)
-            val emulatedBranches: Seq[(cExpr.Expression, cExpr.Expression)] = branches.map({
-              case (condExpr, valueExpr) => {
-                (cExpr.EqualTo(simpleCaseExpression, condExpr), valueExpr)
-              }
-            })
-            cExpr.CaseWhen(emulatedBranches, elseExpr)
+    caseExpr.getCaseExpression match {
+      case e: Any => {
+        val simpleCaseExpression: cExpr.Expression = buildExpressionNoJoinAllowed(e)
+        val emulatedBranches: Seq[(cExpr.Expression, cExpr.Expression)] = branches.map({
+          case (condExpr, valueExpr) => {
+            (cExpr.EqualTo(simpleCaseExpression, condExpr), valueExpr)
           }
-          case _ => cExpr.CaseWhen(branches, elseExpr)
-        }
+        })
+        cExpr.CaseWhen(emulatedBranches, elseExpr)
       }
-      case _ => throw new RuntimeException("According to the grammar implementation, outer CaseExpressions should contain a CaseExpression")
+      case _ => cExpr.CaseWhen(branches, elseExpr)
     }
   }
 

--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/StatementBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/StatementBuilder.scala
@@ -14,7 +14,7 @@ object StatementBuilder {
   def dispatchBuildStatement(statement: oc.Statement): qplan.QNode = {
     statement match {
       case s: oc.SingleQuery => buildStatement(s)
-      case s: oc.RegularQuery => buildStatement(s)
+      case s: oc.CombinedQuery => buildStatement(s)
     }
   }
 
@@ -65,13 +65,11 @@ object StatementBuilder {
     result
   }
 
-  def buildStatement(q: oc.RegularQuery): qplan.QNode = {
-    // the Xtext grammar actually produces a left deep parse tree of a union
-    // so this might be wither a SingleQuery or a RegularQuery, in case of more union's
-    var result = dispatchBuildStatement(q.getSingleQuery)
+  def buildStatement(q: oc.CombinedQuery): qplan.QNode = {
+    var result = buildStatement(q.getSingleQuery)
 
     for (u <- q.getUnion.asScala) {
-      result = qplan.Union(u.isAll, result, dispatchBuildStatement(u.getSingleQuery))
+      result = qplan.Union(u.isAll, result, buildStatement(u.getSingleQuery))
     }
 
     // FIXME: validator

--- a/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TrainBenchmarkCompilationTest.scala
@@ -11,9 +11,13 @@ class TrainBenchmarkCompilationTest extends FunSuite {
   test("Random test from cypher string") {
     TrainBenchmarkCompilationTest.testQueryString(
       """MATCH (segment:Segment)
-        |WHERE NOT NOT NOT (segment.length > 0)
-        |RETURN segment, segment.length AS length
-        |     , case segment.length when +0 then 'zero' when --+-1 then 'almost OK' else 'too bad' end AS lengthComment""".stripMargin)
+        |RETURN segment AS s
+        |UNION
+        |MATCH (segment2:Segment)
+        |RETURN segment2 AS s
+        |UNION ALL
+        |MATCH (segment3:Segment)
+        |RETURN segment3 AS s""".stripMargin)
 
   }
 


### PR DESCRIPTION
This should be merged once we upgrade the openCypher Xtext grammar to a version that includes the appropriate changes.

Ref: slizaa/slizaa-opencypher-xtext#10

Note: the referenced changes introduce incompatible changes to the openCypher Xtext grammar. Upgrading the grammar would break the compiler, and merging this PR should turn it green again.