### PR TITLE
Re-work compilation of SKIP/LIMIT 

### DIFF
--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/QPlanResolver.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/QPlanResolver.scala
@@ -2,6 +2,7 @@ package ingraph.compiler.cypher2qplan
 
 import java.util.concurrent.atomic.AtomicLong
 
+import ingraph.compiler.cypher2qplan.util.TransformUtil
 import ingraph.model.expr.{ProjectionDescriptor, ResolvableName, ReturnItem}
 import ingraph.model.qplan.{QNode, UnaryQNode}
 import ingraph.model.{expr, misc, qplan}
@@ -251,7 +252,10 @@ object QPlanResolver {
       projectionResolveHelper(resolvedProjectList, child)
     }
     case qplan.Selection(condition, child) => qplan.Selection(condition.transform(expressionResolver), child)
-    case qplan.Top(skipExpr, limitExpr, child) => qplan.Top(skipExpr.transform(expressionResolver), limitExpr.transform(expressionResolver), child)
+    case qplan.Top(skipExpr, limitExpr, child) => qplan.Top(
+      TransformUtil.transformOption(skipExpr, expressionResolver)
+      , TransformUtil.transformOption(limitExpr, expressionResolver)
+      , child)
     case qplan.Unwind(expr.UnwindAttribute(collection, alias, resolvedName), child) => qplan.Unwind(expr.UnwindAttribute(collection.transform(expressionResolver), alias, resolvedName), child)
     // DML
     case qplan.Delete(attributes, detach, child) => qplan.Delete(resolveAttributes(attributes, child), detach, child)

--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ReturnBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ReturnBuilder.scala
@@ -118,8 +118,8 @@ object ReturnBuilder {
     val op3 = if (skip == null && limit == null) {
       op2
     } else {
-      val s = if (skip == null) null else BuilderUtil.convertToSkipLimitConstant(skip.getSkip)
-      val l = if (limit == null) null else BuilderUtil.convertToSkipLimitConstant(limit.getLimit)
+      val s = if (skip == null) None else BuilderUtil.convertToSkipLimitConstant(skip.getSkip)
+      val l = if (limit == null) None else BuilderUtil.convertToSkipLimitConstant(limit.getLimit)
       qplan.Top(s, l, op2)
     }
 

--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/util/BuilderUtil.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/util/BuilderUtil.scala
@@ -1,5 +1,6 @@
 package ingraph.compiler.cypher2qplan.util
 
+import ingraph.compiler.cypher2qplan.builders.{ExpressionBuilder, LiteralBuilder}
 import ingraph.model.expr
 import org.apache.spark.sql.catalyst.{expressions => cExpr}
 import org.slizaa.neo4j.opencypher.{openCypher => oc}
@@ -39,12 +40,12 @@ object BuilderUtil {
     else if (isLeftArrow) expr.In else expr.Out
   }
 
-  def convertToSkipLimitConstant(expression: oc.Expression): cExpr.Expression = {
+  def convertToSkipLimitConstant(expression: oc.Expression): Option[cExpr.Expression] = {
     expression match {
-      case e if e == null => null //this is in-line with a null-safe call on expression as it was used before
-      case e: oc.NumberConstant => expr.EStub("Number Literal") //FIXME: LiteralBuilder.buildNumberLiteral(expression, ce)
-      case e: oc.Parameter => expr.EStub("Parameter") //FIXME: buildRelalgParameter(expression, ce)
-      case e => expr.EStub(s"Only NumberConstants and parameters are supported as SKIP/LIMIT values, got ${e.getClass.getName}")
+      case null => None //this is in-line with a null-safe call on expression as it was used before
+      case e: oc.NumberConstant => Some(LiteralBuilder.buildNumberLiteral(e))
+      case e: oc.Parameter => Some(ExpressionBuilder.buildParameter(e))
+      case e => throw new RuntimeException(s"Only NumberConstants and parameters are supported as SKIP/LIMIT values, got ${e.getClass.getName}")
     }
   }
 }

--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/util/TransformUtil.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/util/TransformUtil.scala
@@ -1,0 +1,12 @@
+package ingraph.compiler.cypher2qplan.util
+
+import org.apache.spark.sql.catalyst.{expressions => cExpr}
+
+object TransformUtil {
+  def transformOption(optionExpression: Option[cExpr.Expression], transformRule: PartialFunction[cExpr.Expression, cExpr.Expression]): Option[cExpr.Expression] = {
+    optionExpression match {
+      case None => None
+      case Some(e) => Some(e.transform(transformRule))
+    }
+  }
+}

--- a/compiler/src/main/scala/ingraph/model/jplan.scala
+++ b/compiler/src/main/scala/ingraph/model/jplan.scala
@@ -77,8 +77,8 @@ case class Unwind(unwindAttribute: UnwindAttribute, child: JNode) extends UnaryJ
   // TODO indexOf might be unable to find the attribute
 }
 
-case class SortAndTop(skipExpr: Expression,
-                      limitExpr: Expression,
+case class SortAndTop(skipExpr: Option[Expression],
+                      limitExpr: Option[Expression],
                       order: Seq[SortOrder],
                       child: JNode) extends UnaryJNode {}
 

--- a/compiler/src/main/scala/ingraph/model/qplan.scala
+++ b/compiler/src/main/scala/ingraph/model/qplan.scala
@@ -100,7 +100,7 @@ case class Selection(condition: Expression, child: QNode) extends UnaryQNode {}
 
 case class Sort(order: Seq[SortOrder], child: QNode) extends UnaryQNode {}
 
-case class Top(skipExpr: Expression, limitExpr: Expression, child: QNode) extends UnaryQNode {}
+case class Top(skipExpr: Option[Expression] = None, limitExpr: Option[Expression] = None, child: QNode) extends UnaryQNode {}
 
 case class Unwind(unwindAttribute: UnwindAttribute, child: QNode) extends UnaryQNode {
   override def output = child.output ++ Seq(unwindAttribute) // child.output.updated(child.output.indexOf(element), element)

--- a/compiler/src/test/scala/ingraph/sandbox/RandomCompilationTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/RandomCompilationTest.scala
@@ -2,14 +2,14 @@ package ingraph.sandbox
 
 class RandomCompilationTest extends CompilerTest {
   override val config = CompilerTestConfig(querySuitePath = None
-    , compileQPlanOnly = true
+    , compileQPlanOnly = false
     , skipQPlanResolve = false
     , skipQPlanBeautify = false
     , printQuery = false
     , printCypher = true
     , printQPlan = true
-    , printJPlan = false
-    , printFPlan = false
+    , printJPlan = true
+    , printFPlan = true
   )
 
   test("Random test from cypher string") {
@@ -103,6 +103,34 @@ class RandomCompilationTest extends CompilerTest {
       """MATCH (n:Person)
         |WHERE n.name IS NOT NULL
         |RETURN n, n.name""".stripMargin
+    )
+  }
+
+  test("Random: LIMIT w/o SKIP") {
+    compile(
+      """MATCH (p:Person)
+        |RETURN p
+        |ORDER BY 1
+        |LIMIT 10""".stripMargin
+    )
+  }
+
+  test("Random: SKIP w/o LIMIT") {
+    compile(
+      """MATCH (p:Person)
+        |RETURN p
+        |ORDER BY 1
+        |SKIP 3""".stripMargin
+    )
+  }
+
+  test("Random: SKIP w/ LIMIT") {
+    compile(
+      """MATCH (p:Person)
+        |RETURN p
+        |ORDER BY 1
+        |SKIP 3
+        |LIMIT 10""".stripMargin
     )
   }
 }

--- a/ire-adapter/src/main/scala/ingraph/ire/EngineFactory.scala
+++ b/ire-adapter/src/main/scala/ingraph/ire/EngineFactory.scala
@@ -155,10 +155,8 @@ object EngineFactory {
       // This is the mighty EMF, so there are no default values, obviously
       def getInt(e: Expression) = ExpressionParser.parseValue(e, variableLookup)(Vector()).asInstanceOf[Long]
 
-      // FIXME: Option.getOrElse(null) emulates old behaviour: before skipExpr and limitExpr became Option, they contained null in some cases
-      // FIXME (cont): but SortAndTopNode does not seem to handle missing values, i.e. missing limit value. skip might default to 0, but I know no suitable integer default for limit
-      val skip: Long = getInt(op.jnode.skipExpr.getOrElse(null))
-      val limit: Long = getInt(op.jnode.limitExpr.getOrElse(null))
+      val skip: Option[Long] = op.jnode.skipExpr.map(getInt)
+      val limit: Option[Long] = op.jnode.limitExpr.map(getInt)
       val sortKeys = op.jnode.order.map(
         e => ExpressionParser.parseValue(e, variableLookup)).toVector
       newLocal(Props(new SortAndTopNode(

--- a/ire-adapter/src/main/scala/ingraph/ire/EngineFactory.scala
+++ b/ire-adapter/src/main/scala/ingraph/ire/EngineFactory.scala
@@ -155,8 +155,10 @@ object EngineFactory {
       // This is the mighty EMF, so there are no default values, obviously
       def getInt(e: Expression) = ExpressionParser.parseValue(e, variableLookup)(Vector()).asInstanceOf[Long]
 
-      val skip: Long = getInt(op.jnode.skipExpr)
-      val limit: Long = getInt(op.jnode.limitExpr)
+      // FIXME: Option.getOrElse(null) emulates old behaviour: before skipExpr and limitExpr became Option, they contained null in some cases
+      // FIXME (cont): but SortAndTopNode does not seem to handle missing values, i.e. missing limit value. skip might default to 0, but I know no suitable integer default for limit
+      val skip: Long = getInt(op.jnode.skipExpr.getOrElse(null))
+      val limit: Long = getInt(op.jnode.limitExpr.getOrElse(null))
       val sortKeys = op.jnode.order.map(
         e => ExpressionParser.parseValue(e, variableLookup)).toVector
       newLocal(Props(new SortAndTopNode(

--- a/ire-adapter/src/test/scala/ingraph/ire/TrainbenchmarkBatchIntegrationTest.scala
+++ b/ire-adapter/src/test/scala/ingraph/ire/TrainbenchmarkBatchIntegrationTest.scala
@@ -28,10 +28,17 @@ class TrainbenchmarkBatchIntegrationTest extends FunSuite {
     }
   )
 
-  ignore("SortAndTopNode") {
+  test("Sort with Limit works") {
     val query = "MATCH (n: Segment) RETURN n ORDER BY n DESC SKIP 5 LIMIT 10"
     val results = TrainbenchmarkUtils.readModelAndGetResults(query, 1)
     val expected = ((1400 to 1410).toSet - 1405).toList.sorted.reverse.map(n => Vector(n.toLong))
+    assert(results == expected)
+  }
+
+  test("Sort without Limit works") {
+    val query = "MATCH (n: Segment) RETURN n ORDER BY n DESC SKIP 1100"
+    val results = TrainbenchmarkUtils.readModelAndGetResults(query, 1)
+    val expected = (7 to 9).reverse.map(n => Vector(n.toLong))
     assert(results == expected)
   }
 }

--- a/ire/src/main/scala/hu/bme/mit/ire/nodes/unary/SortAndTopNode.scala
+++ b/ire/src/main/scala/hu/bme/mit/ire/nodes/unary/SortAndTopNode.scala
@@ -9,12 +9,16 @@ import hu.bme.mit.ire.util.{GenericMath, SizeCounter}
 
 import scala.collection.immutable.VectorBuilder
 
-class SortNode(override val next: (ReteMessage) => Unit,
-                   tupleLength: Int,
-                   selectionMask: Vector[(Tuple) => Any],
-                   ascendingOrder: Vector[Boolean])
+class SortAndTopNode(override val next: (ReteMessage) => Unit,
+                     tupleLength: Int,
+                     selectionMask: Vector[(Tuple) => Any],
+                     skip: Option[Long],
+                     limit: Option[Long],
+                     ascendingOrder: Vector[Boolean])
   extends UnaryNode with SingleForwarder {
 
+  val longSkip = skip.getOrElse(0L)
+  val longLimit = limit.getOrElse(Long.MaxValue / 2L)
   //implicit val order = new Ordering[Tuple] {
   val comparator = new Comparator[Tuple] {
     override def compare(x: Tuple, y: Tuple): Int = {
@@ -45,42 +49,31 @@ class SortNode(override val next: (ReteMessage) => Unit,
   val data: java.util.Map[Tuple, Int] = new java.util.TreeMap(comparator)
   //null //mutable.TreeMap[Tuple, Int]().withDefault(t => 0)
 
-//  val maskInverse: Mask = Vector.range(0, tupleLength).filter(i => !selectionMask.contains(i))
-
   def keyLookup(t: Tuple): Vector[Any] = selectionMask.map(m => m(t))
-//  def inverseKeyLookup(t: Tuple): Vector[Any] = maskInverse.map(t(_))
 
   def getTuplesInOrder: Vector[Tuple] = {
-    var total = 0
-    //val iterator: Iterator[(Tuple, Int)] = data.iterator
+    var total: Long = 0
     val iterator = data.entrySet.iterator
     val builder = new VectorBuilder[Tuple]
-    while (iterator.hasNext) {
-//      val (tuple, count) = iterator.next()
+    while (total < longLimit + longSkip && iterator.hasNext) {
       val entry = iterator.next
       val tuple = entry.getKey
       val count = entry.getValue
-      for (i <- 0 until count)
+      for (i <- 0L until math.min(count, longLimit + longSkip - total))
         builder += tuple
       total += count
     }
-    builder.result()
+    builder.result().drop(longSkip.toInt)
   }
 
   override def onChangeSet(changeSet: ChangeSet): Unit = {
     // TODO maybe checking the changed elements against the lowest forwarded element would speed things up
     val prevTop = getTuplesInOrder
     for (tuple <- changeSet.positive) {
-//      data(tuple) += 1
       val count : Int = Some(data.get(tuple)).getOrElse(0)
       data.put(tuple, count + 1)
     }
     for (tuple <- changeSet.negative) {
-//      if (data(tuple) > 1) {
-//        data(tuple) -= 1
-//      } else {
-//        data.remove(tuple)
-//      }
       val count = data.get(tuple)
       if (count >  1) {
         data.put(tuple, count - 1)
@@ -95,32 +88,5 @@ class SortNode(override val next: (ReteMessage) => Unit,
   }
 
   // TODO we can simplify this in 2.12
-//  override def onSizeRequest(): Long = SizeCounter.count(data.keys)
   override def onSizeRequest(): Long = SizeCounter.count(data.keySet)
-}
-
-class SortAndTopNode(next: (ReteMessage) => Unit,
-                     tupleLength: Int,
-                     selectionMask: Vector[(Tuple) => Any],
-                     skip: Long,
-                     limit: Long,
-                     ascendingOrder: Vector[Boolean])
-  extends SortNode(next, tupleLength, selectionMask, ascendingOrder) {
-
-  override def getTuplesInOrder: Vector[Tuple] = {
-    var total: Long = 0
-    //val iterator: Iterator[(Tuple, Int)] = data.iterator
-    val iterator = data.entrySet.iterator
-    val builder = new VectorBuilder[Tuple]
-    while (total < limit + skip && iterator.hasNext) {
-      //      val (tuple, count) = iterator.next()
-      val entry = iterator.next
-      val tuple = entry.getKey
-      val count = entry.getValue
-      for (i <- 0L until math.min(count, limit + skip - total))
-        builder += tuple
-      total += count
-    }
-    builder.result().drop(skip.toInt)
-  }
 }

--- a/ire/src/test/scala/hu/bme/mit/ire/nodes/unary/SortAndTopNodeTest.scala
+++ b/ire/src/test/scala/hu/bme/mit/ire/nodes/unary/SortAndTopNodeTest.scala
@@ -23,8 +23,8 @@ class SortAndTopNodeTest(_system: ActorSystem) extends TestKit(_system) with Imp
           new SortAndTopNode(echoActor ! _,
               tupleLength = 3,
               selectionMask = selectionMask,
-              skip = 0,
-              limit = 2,
+              skip = Some(0),
+              limit = Some(2),
               ascendingOrder = Vector(true, false))
       ))
 
@@ -41,8 +41,8 @@ class SortAndTopNodeTest(_system: ActorSystem) extends TestKit(_system) with Imp
       val counter = system.actorOf(Props(new SortAndTopNode(echoActor ! _,
           tupleLength = 3,
           selectionMask = selectionMask,
-          skip = 0,
-          limit = 2,
+          skip = Some(0),
+          limit = Some(2),
           ascendingOrder = Vector(true, true))))
 
       counter ! ChangeSet(positive = tupleBag(tuple(0, 1, 2), tuple(0, 1, 2), tuple(0, 1, 3)))


### PR DESCRIPTION
i.e. `Top` and `SortAndTop` operators now accomodate `Option[Expression]`

These plan elements included expression stub up for their `skip` and `limit` properties. From now on, they are populated, but the metamodel has been reworked to include a `Option[Expression]` instead of `Expression` allowing null.

@wafle please review and maybe correct my dirty hack on ire-adapter

Note: meaningful compilation of `ORDER BY` is coming soon.