### PR TITLE
Grammar: use unwrapped ReturnBody.returnItems model

### DIFF
--- a/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ReturnBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2qplan/builders/ReturnBuilder.scala
@@ -48,9 +48,7 @@ object ReturnBuilder {
     * i.e. the distinct flag and the ReturnBody.
     */
   def buildReturnBody(distinct: Boolean, returnBody: oc.ReturnBody, content: qplan.QNode): qplan.QNode = {
-    // FIXME (in the grammar): returnBody.returnItems.get(0) is the actual return item list
-    // but it should be w/o .get(0)
-    val returnItems = returnBody.getReturnItems.get(0)
+    val returnItems = returnBody.getReturnItems
 
     // this will hold the project list compiled
     val elements = ListBuffer[expr.ReturnItem]()

--- a/compiler/src/test/scala/ingraph/sandbox/RandomCompilationTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/RandomCompilationTest.scala
@@ -157,4 +157,14 @@ class RandomCompilationTest extends CompilerTest {
         |ORDER BY c.name""".stripMargin
     )
   }
+
+  test("Random: 2-part query featuring WITH") {
+    compile(
+      """MATCH (p:Person)
+        |WITH DISTINCT p
+        |MATCH (p)-->(c:Car)
+        |RETURN p, c
+      """.stripMargin
+    )
+  }
 }


### PR DESCRIPTION
This should be merged once we upgrade the openCypher Xtext grammar to a version that includes the appropriate changes.

Ref: slizaa/slizaa-opencypher-xtext#14

Note: the referenced changes introduce incompatible changes to the openCypher Xtext grammar. Upgrading the grammar would break the compiler, and merging this PR should turn it green again.