### PR TITLE
Add test for index range expression issue #306

### DIFF
--- a/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
@@ -1,8 +1,9 @@
 package ingraph.sandbox
 
 import ingraph.compiler.test.CompilerTest
-import ingraph.model.fplan.{FNode, LeafFNode, Selection}
-import ingraph.model.{nplan, fplan}
+import ingraph.model.expr.{IndexLookupExpression, IndexRangeExpression}
+import ingraph.model.fplan.{FNode, LeafFNode, Selection, TransitiveJoin}
+import ingraph.model.{fplan, gplan, nplan}
 
 class TckCompilerTest extends CompilerTest {
 
@@ -148,7 +149,7 @@ class TckCompilerTest extends CompilerTest {
         """.stripMargin
       )
       val edgeListAttribute = getNodes(stages.fplan)
-        .collectFirst { case node: fplan.TransitiveJoin => node }
+        .collectFirst { case node: TransitiveJoin => node }
         .get.nnode.edgeList
 
       assert(edgeListAttribute.minHops == lowerBound)
@@ -163,6 +164,45 @@ class TckCompilerTest extends CompilerTest {
   variableLengthPatternTest("Variable-length pattern: upper bound", "..2", None, Some(2))
   variableLengthPatternTest("Variable-length pattern: same lower and upper bounds", "2..2", Some(2), Some(2))
   variableLengthPatternTest("Variable-length pattern: zero as lower bound", "0..", Some(0), None)
+
+  test("Index expression") {
+    val stages = compile(
+      "RETURN range(0,10)[2]"
+    )
+
+    val actualIndex = stages.gplan.asInstanceOf[gplan.Production]
+      .child.asInstanceOf[gplan.Projection]
+      .projectList
+      .head
+      .child.asInstanceOf[IndexLookupExpression]
+      .index
+
+    assert(2 == actualIndex)
+  }
+
+  def indexRangeExpressionTest(testName: String, lowerBound: Option[Int], upperBound: Option[Int]): Unit = {
+    test(testName) {
+      val lowerBoundString = lowerBound.getOrElse("")
+      val upperBoundString = upperBound.getOrElse("")
+
+      val stages = compile(
+        s"RETURN range(0,10)[$lowerBoundString..$upperBoundString]"
+      )
+
+      val indexRangeExpression = stages.gplan.asInstanceOf[gplan.Production]
+        .child.asInstanceOf[gplan.Projection]
+        .projectList
+        .head
+        .child.asInstanceOf[IndexRangeExpression]
+
+      assert(lowerBound == indexRangeExpression.lower)
+      assert(upperBound == indexRangeExpression.upper)
+    }
+  }
+
+  indexRangeExpressionTest("Index range expression: both bound", Some(2), Some(5))
+  indexRangeExpressionTest("Index range expression: lower bound", Some(2), None)
+  indexRangeExpressionTest("Index range expression: upper bound", None, Some(5))
 
   ignore("Start with WITH") {
     val stages = compile(


### PR DESCRIPTION
The Slizaa openCypher M10 grammar that we use in the master parses these cases and the compilation seems correct for me. The tests passes - thank you @marci543 for creating them!

Closes #306.