### PR TITLE
Use parsed text from query as name for unnamed columns

### DIFF
--- a/compiler/src/main/scala/ingraph/compiler/cypher2gplan/GPlanResolver.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2gplan/GPlanResolver.scala
@@ -207,7 +207,7 @@ object GPlanResolver {
         case expr.PropertyAttribute(name, elementAttribute, _) => expr.PropertyAttribute(name,
           // see "scoped name resolver shorthand" above
           elementAttribute.transform(expressionNameResolver(snr)).asInstanceOf[expr.ElementAttribute],
-          snr.resolve(s"${elementAttribute.name}$$${name}", rn))
+          snr.resolve(s"${elementAttribute.name}.${name}", rn))
         case expr.UnwindAttribute(list, name, _) => expr.UnwindAttribute(list, name, snr.resolve(name, rn))
       }
     case UnresolvedAttribute(nameParts) => nameParts.length match {
@@ -240,7 +240,7 @@ object GPlanResolver {
           elementAttribute match {
             // if nameParts.length == 2, base should always be an ElementAttribute
             case ea: expr.ElementAttribute =>
-              expr.PropertyAttribute(propertyName, ea, snr.resolve(s"${ea.name}$$${propertyName}",
+              expr.PropertyAttribute(propertyName, ea, snr.resolve(s"${ea.name}.${propertyName}",
                 expr.PropertyAttribute(propertyName, ea)) // this is a dirty hack to tell the resolver that we are about to resolve a PropertyAttribute instance
               )
             case x => throw new UnexpectedTypeException(x, "basis position of property dereferencing")

--- a/compiler/src/main/scala/ingraph/compiler/cypher2gplan/builders/ReturnBuilder.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2gplan/builders/ReturnBuilder.scala
@@ -5,6 +5,7 @@ import ingraph.compiler.cypher2gplan.util.GrammarUtil._
 import ingraph.model.{expr, gplan}
 import org.apache.spark.sql.catalyst.analysis.UnresolvedStar
 import org.apache.spark.sql.catalyst.{expressions => cExpr}
+import org.slizaa.neo4j.opencypher.openCypher.VariableRef
 import org.slizaa.neo4j.opencypher.{openCypher => oc}
 
 import scala.collection.JavaConverters._
@@ -49,9 +50,10 @@ object ReturnBuilder {
     for (returnItem <- returnItems.getItems.asScala) {
       val e = ExpressionBuilder.buildExpressionNoJoinAllowed(returnItem.getExpression)
 
-      // use parsed text from query as alias if no name is available in a RETURN clause
+      // use parsed text from query as alias if no column name is available in a RETURN clause
+      // for VariableRef there's no need to override the name of the variable
       val parsedText =
-        if (isReturnClause) Some(returnItem.parsedText)
+        if (isReturnClause && !returnItem.getExpression.isInstanceOf[VariableRef]) Some(returnItem.parsedText)
         else None
       val alias = Option(returnItem.getAlias)
         .map(_.getName)

--- a/compiler/src/main/scala/ingraph/compiler/cypher2gplan/util/GrammarUtil.scala
+++ b/compiler/src/main/scala/ingraph/compiler/cypher2gplan/util/GrammarUtil.scala
@@ -2,6 +2,7 @@ package ingraph.compiler.cypher2gplan.util
 
 
 import org.eclipse.emf.ecore.EObject
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.slizaa.neo4j.opencypher.{openCypher => oc}
 
 /**
@@ -23,4 +24,17 @@ object GrammarUtil {
 			case _ => false
 		}
 	}
+
+  implicit class EObjectExtensions(val obj: EObject) extends AnyVal {
+    def parsedText: String = {
+      val node = NodeModelUtils.findActualNodeFor(obj)
+
+      // not using INode.getText(), because that includes hidden tokens too
+      val beginIndex = node.getOffset
+      val endIndex = node.getEndOffset
+      val rootText = node.getRootNode.getText
+
+      rootText.substring(beginIndex, endIndex)
+    }
+  }
 }

--- a/compiler/src/main/scala/ingraph/model/fplan.scala
+++ b/compiler/src/main/scala/ingraph/model/fplan.scala
@@ -64,7 +64,7 @@ case class Production(nnode: nplan.Production,
                       child: FNode
                      ) extends UnaryFNode with TProduction {
   override def output = nnode.output
-  def outputNames: Iterable[String] = output.map(_.resolvedName.get.resolvedName.replaceAll("#\\d+$", "").replace('$', '.'))
+  def outputNames: Iterable[String] = output.map(_.resolvedName.get.resolvedName.replaceAll("#\\d+$", ""))
 }
 
 case class Projection(requiredProperties: Seq[ResolvableName],

--- a/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
@@ -2,8 +2,8 @@ package ingraph.sandbox
 
 import ingraph.compiler.test.CompilerTest
 import ingraph.model.expr.{IndexLookupExpression, IndexRangeExpression}
-import ingraph.model.fplan.{FNode, LeafFNode, Selection, TransitiveJoin}
-import ingraph.model.{fplan, gplan, nplan}
+import ingraph.model.fplan._
+import ingraph.model.gplan
 
 class TckCompilerTest extends CompilerTest {
 
@@ -212,6 +212,17 @@ class TckCompilerTest extends CompilerTest {
       """.stripMargin
     )
     findFirstByType(stages.fplan, classOf[Selection]).conditionTuple
+  }
+
+  test("Unnamed columns") {
+    val stages = compile(
+      """MATCH (n)
+        |RETURN n, (n :Label), n. /**/ id, count(n)
+      """.stripMargin
+    )
+    val expectedColumnNames = Array("n", "(n :Label)", "n. /**/ id", "count(n)")
+    val actualColumnNames = stages.fplan.asInstanceOf[Production].outputNames.toArray
+    assert(expectedColumnNames sameElements actualColumnNames)
   }
 
   ignore("Placeholder for debugging plans") {

--- a/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
+++ b/compiler/src/test/scala/ingraph/sandbox/TckCompilerTest.scala
@@ -217,12 +217,12 @@ class TckCompilerTest extends CompilerTest {
   test("Unnamed columns") {
     val stages = compile(
       """MATCH (n)
-        |RETURN n, (n :Label), n. /**/ id, count(n)
+        |RETURN `n`, (n :Label), n. /**/ `id`, count(n), 1 + 1, $`param`
       """.stripMargin
     )
-    val expectedColumnNames = Array("n", "(n :Label)", "n. /**/ id", "count(n)")
-    val actualColumnNames = stages.fplan.asInstanceOf[Production].outputNames.toArray
-    assert(expectedColumnNames sameElements actualColumnNames)
+    val expectedColumnNames = Seq("n", "(n :Label)", "n. /**/ `id`", "count(n)", "1 + 1", "$`param`")
+    val actualColumnNames = stages.fplan.asInstanceOf[Production].outputNames.toSeq
+    assert(expectedColumnNames == actualColumnNames)
   }
 
   ignore("Placeholder for debugging plans") {


### PR DESCRIPTION
Use expression instead of `_expr` as column name if the column has no alias, e.g. `count(*)`.
https://github.com/FTSRG/ingraph/blob/db71f51f5ead36a6c7aeee9bbb61b68c8df5b729/compiler/src/main/scala/ingraph/compiler/cypher2gplan/GPlanResolver.scala#L151

Test case: https://github.com/FTSRG/ingraph/pull/367/commits/dc1cb5956e358769588da21d522e75a9e416cb00#diff-7c3111ac35db49278487e33313f7bc2fR217